### PR TITLE
fix Looper.loop() location in location providers

### DIFF
--- a/privacystreams-core/src/main/java/com/github/privacystreams/location/CurrentLocationProvider.java
+++ b/privacystreams-core/src/main/java/com/github/privacystreams/location/CurrentLocationProvider.java
@@ -50,8 +50,8 @@ final class CurrentLocationProvider extends SStreamProvider {
         else {
             provider = LocationManager.NETWORK_PROVIDER;
         }
-        Looper.loop();
         locationManager.requestLocationUpdates(provider, minTime, minDistance, locationListener);
+        Looper.loop();
     }
 
     @Override

--- a/privacystreams-core/src/main/java/com/github/privacystreams/location/LocationUpdatesProvider.java
+++ b/privacystreams-core/src/main/java/com/github/privacystreams/location/LocationUpdatesProvider.java
@@ -52,8 +52,8 @@ final class LocationUpdatesProvider extends MStreamProvider {
         else {
             provider = LocationManager.NETWORK_PROVIDER;
         }
-        Looper.loop();
         locationManager.requestLocationUpdates(provider, minTime, minDistance, locationListener);
+        Looper.loop();
     }
 
     @Override


### PR DESCRIPTION
The two occurances of Looper.loop() should be after location APIs, otherwise they're never reachable, causing location information fetching failed.